### PR TITLE
fix: resolve Swift 6 Sendable error and redundant public modifiers

### DIFF
--- a/Sources/CoreDataContextParent.swift
+++ b/Sources/CoreDataContextParent.swift
@@ -1,4 +1,4 @@
-import CoreData
+@preconcurrency import CoreData
 import Foundation
 
 /// Represents the parent of a Core Data context.

--- a/Sources/NSManagedObjectContext+Context.swift
+++ b/Sources/NSManagedObjectContext+Context.swift
@@ -185,7 +185,7 @@ public extension NSManagedObjectContext {
         }
     }
     
-    public func batchUpdate(entityName: String, propertiesToUpdate: [AnyHashable: Any]?, predicate: NSPredicate?) async throws {
+    func batchUpdate(entityName: String, propertiesToUpdate: [AnyHashable: Any]?, predicate: NSPredicate?) async throws {
         try await perform {
             let request = NSBatchUpdateRequest(entityName: entityName)
             request.propertiesToUpdate = propertiesToUpdate


### PR DESCRIPTION
- Add @preconcurrency import to CoreDataContextParent.swift to suppress Sendable conformance error for NSManagedObjectContext associated value
- Remove redundant public modifiers from methods inside public extension in NSManagedObjectContext+Context.swift

https://claude.ai/code/session_01TNsEL7diizizJaMYV84X4r