### PR TITLE
fix: add missing await to async fetchOne calls in tests

### DIFF
--- a/Tests/TestContextExtensions.swift
+++ b/Tests/TestContextExtensions.swift
@@ -236,7 +236,7 @@ final class TestContextExtensions: XCTestCase {
 
         let request = FetchRequest<MockUser>(verifyContext)
             .filtered(key: "name", equalTo: "Persistent")
-        let result = try verifyContext.fetchOne(request)
+        let result = try await verifyContext.fetchOne(request)
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.age, 55)
     }

--- a/Tests/TestCoreDataStack.swift
+++ b/Tests/TestCoreDataStack.swift
@@ -87,7 +87,7 @@ final class TestCoreDataStack: XCTestCase {
 
         // Verify data is accessible after persistent save
         let request = FetchRequest<MockUser>(db.mainContext).filtered(key: "name", equalTo: "PersistentUser")
-        let result = try db.mainContext.fetchOne(request)
+        let result = try await db.mainContext.fetchOne(request)
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.age, 42)
     }


### PR DESCRIPTION
In async test methods, Swift 6 resolves fetchOne to the async overload which requires await.

https://claude.ai/code/session_01TNsEL7diizizJaMYV84X4r